### PR TITLE
user 기능, dive log 작성 구현 (회원가입, 로그인, 로그아웃, 세션확인, 다이빙 로그 작성)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application.yml

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 
-application.yml
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	//Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/divelink/server/DiveLinkApplication.java
+++ b/src/main/java/com/divelink/server/DiveLinkApplication.java
@@ -2,7 +2,9 @@ package com.divelink.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DiveLinkApplication {
 

--- a/src/main/java/com/divelink/server/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/divelink/server/config/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.divelink.server.config;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+    this.jwtTokenProvider = jwtTokenProvider;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String token = getJwtFromRequest(request);
+
+    if (token != null) {
+      System.out.println("!!!!!! ===> JWT Token: " + token);
+    }
+
+    if (token != null && jwtTokenProvider.validateToken(token)) {
+      String userId = jwtTokenProvider.getUserIdFromToken(token);
+      UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, null);
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  // 요청에서 JWT 토큰을 추출하는 메소드
+  private String getJwtFromRequest(HttpServletRequest request) {
+    String bearerToken = request.getHeader("Authorization");
+    if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7); // "Bearer " 이후의 토큰만 반환
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/divelink/server/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/divelink/server/config/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.divelink.server.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -10,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenProvider jwtTokenProvider;
@@ -25,7 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     String token = getJwtFromRequest(request);
 
     if (token != null) {
-      System.out.println("!!!!!! ===> JWT Token: " + token);
+      log.info("JWT Token: {}", token);
     }
 
     if (token != null && jwtTokenProvider.validateToken(token)) {

--- a/src/main/java/com/divelink/server/config/JwtTokenProvider.java
+++ b/src/main/java/com/divelink/server/config/JwtTokenProvider.java
@@ -1,0 +1,42 @@
+package com.divelink.server.config;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+  private final String SECRET_KEY = "mySuperSecretKeyThatIsAtLeast512BitsLongAndMoreSecureThanBeforemySuperSecretKeyThatIsAtLeast512BitsLongAndMoreSecureThanBefore";
+
+  // JWT 토큰 생성
+  public String generateToken(String userId) {
+    return Jwts.builder()
+        .setSubject(userId) // 사용자 정보
+        .setIssuedAt(new Date()) // 토큰 발급 시간
+        .setExpiration(new Date(System.currentTimeMillis() + 86400000)) // 만료 시간 1일
+        .signWith(SignatureAlgorithm.HS512, SECRET_KEY) // 서명
+        .compact();
+  }
+
+  // JWT 토큰 검증
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  // JWT 토큰에서 사용자 정보 추출
+  public String getUserIdFromToken(String token) {
+    return Jwts.parser()
+        .setSigningKey(SECRET_KEY)
+        .parseClaimsJws(token)
+        .getBody()
+        .getSubject();
+  }
+}

--- a/src/main/java/com/divelink/server/config/SecurityConfig.java
+++ b/src/main/java/com/divelink/server/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.divelink.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable) // 기본 로그인 페이지 사용 안 함(postman으로 테스트 할거라서)
+        .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증도 꺼야함
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/users/register", "/users/login", "/users/logout", "/users/session").permitAll()
+            .anyRequest().authenticated()
+        );
+
+    return http.build();
+
+  }
+
+}

--- a/src/main/java/com/divelink/server/config/SecurityConfig.java
+++ b/src/main/java/com/divelink/server/config/SecurityConfig.java
@@ -1,21 +1,26 @@
 package com.divelink.server.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
   private final JwtTokenProvider jwtTokenProvider;
 
-  public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
-    this.jwtTokenProvider = jwtTokenProvider;
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
   }
 
   @Bean

--- a/src/main/java/com/divelink/server/controller/DiveLogController.java
+++ b/src/main/java/com/divelink/server/controller/DiveLogController.java
@@ -3,6 +3,7 @@ package com.divelink.server.controller;
 import com.divelink.server.dto.DiveLogRequest;
 import com.divelink.server.service.DiveLogService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,13 +19,11 @@ public class DiveLogController {
 
   @PostMapping("write")
   public ResponseEntity<String> writeLog(@RequestBody DiveLogRequest request){
-    String result;
-    String saved = diveLogService.saveLog(request);
-    if(saved.equals("s")){
-      result = "저장 성공";
-    }else{
-      result = "저장 실패. " + saved;
+    try{
+      diveLogService.saveLog(request);
+      return ResponseEntity.status(HttpStatus.CREATED).body("저장 성공");
+    }catch(Exception e){
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("저장 실패" + e.getMessage());
     }
-    return ResponseEntity.ok(result);
   }
 }

--- a/src/main/java/com/divelink/server/controller/DiveLogController.java
+++ b/src/main/java/com/divelink/server/controller/DiveLogController.java
@@ -1,0 +1,30 @@
+package com.divelink.server.controller;
+
+import com.divelink.server.dto.DiveLogRequest;
+import com.divelink.server.service.DiveLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/logs")
+@RequiredArgsConstructor
+public class DiveLogController {
+
+  private final DiveLogService diveLogService;
+
+  @PostMapping("write")
+  public ResponseEntity<String> writeLog(@RequestBody DiveLogRequest request){
+    String result;
+    String saved = diveLogService.saveLog(request);
+    if(saved.equals("s")){
+      result = "저장 성공";
+    }else{
+      result = "저장 실패. " + saved;
+    }
+    return ResponseEntity.ok(result);
+  }
+}

--- a/src/main/java/com/divelink/server/controller/UserController.java
+++ b/src/main/java/com/divelink/server/controller/UserController.java
@@ -4,13 +4,11 @@ import com.divelink.server.config.JwtTokenProvider;
 import com.divelink.server.dto.UserLoginRequest;
 import com.divelink.server.dto.UserRegisterRequest;
 import com.divelink.server.service.UserService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.graphql.GraphQlProperties.Http;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,18 +25,33 @@ public class UserController {
 
   @PostMapping("/register")
   public ResponseEntity<String> register(@RequestBody @Valid UserRegisterRequest request){
-    userService.register(request.getUserId(), request.getName(), request.getBirthday(), request.getPassword());
-    return ResponseEntity.ok("회원가입 완료");
+    try{
+      boolean successRegister = userService.register(request.getUserId(), request.getName(), request.getBirthday(), request.getPassword());
+      if(successRegister){
+        return ResponseEntity.ok("회원가입 완료");
+      }else{
+        return ResponseEntity.status(HttpStatus.CONFLICT).body("등록 실패(이미 존재하는 아이디)");
+      }
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("회원 등록 중 예외 발생: " + e.getMessage());
+    }
   }
 
   @PostMapping("/login")
-  public ResponseEntity<String> login(@RequestBody @Valid UserLoginRequest request){
-    boolean passed = userService.login(request.getUserId(), request.getPassword());
-    if (passed) {
-      String token = jwtTokenProvider.generateToken(request.getUserId());
-      return ResponseEntity.ok("로그인 성공. JWT: " + token);
-    } else {
-      return ResponseEntity.status(401).body("로그인 실패");
+  public ResponseEntity<String> login(@RequestBody @Valid UserLoginRequest request, HttpSession session){
+    try{
+      boolean loginSuccess = userService.login(request.getUserId(), request.getPassword());
+
+      if(loginSuccess){
+        String token = jwtTokenProvider.generateToken(request.getUserId());
+        session.setAttribute("USER_ID", request.getUserId());
+        return ResponseEntity.ok("로그인 성공. JWT: " + token);
+      }else{
+        //아이디/비번 불일치 등
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 실패: 잘못된 데이터");
+      }
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그인 처리 중 오류 발생: " + e.getMessage());
     }
   }
 

--- a/src/main/java/com/divelink/server/controller/UserController.java
+++ b/src/main/java/com/divelink/server/controller/UserController.java
@@ -1,0 +1,61 @@
+package com.divelink.server.controller;
+
+import com.divelink.server.dto.UserLoginRequest;
+import com.divelink.server.dto.UserRegisterRequest;
+import com.divelink.server.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties.Http;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserService userService;
+
+  @PostMapping("/register")
+  public ResponseEntity<String> register(@RequestBody @Valid UserRegisterRequest request){
+    userService.register(request.getUserId(), request.getName(), request.getBirthday(), request.getPassword());
+    return ResponseEntity.ok("회원가입 완료");
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<String> login(@RequestBody @Valid UserLoginRequest request, HttpServletRequest httpRequest){
+    String result;
+
+    boolean passed = userService.login(request.getUserId(), request.getPassword());
+    if (passed) {
+      HttpSession session = httpRequest.getSession(true);
+      session.setAttribute("USER_ID", request.getUserId());
+      return ResponseEntity.ok("로그인 완료");
+    } else {
+      return ResponseEntity.status(401).body("로그인 실패");
+    }
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<String> logout(HttpSession session){
+    session.invalidate();
+    return ResponseEntity.ok("로그아웃 완료");
+  }
+
+  @GetMapping("/session")
+  private ResponseEntity<String> checkSession(HttpSession session){
+    String userId = (String) session.getAttribute("USER_ID");
+    if(userId != null){
+      return ResponseEntity.ok("세션 있음 userId: " + userId);
+    }else{
+      return ResponseEntity.ok("세션 없음");
+    }
+  }
+}

--- a/src/main/java/com/divelink/server/controller/UserController.java
+++ b/src/main/java/com/divelink/server/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.divelink.server.controller;
 
+import com.divelink.server.config.JwtTokenProvider;
 import com.divelink.server.dto.UserLoginRequest;
 import com.divelink.server.dto.UserRegisterRequest;
 import com.divelink.server.service.UserService;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
   private final UserService userService;
+  private final JwtTokenProvider jwtTokenProvider;
 
   @PostMapping("/register")
   public ResponseEntity<String> register(@RequestBody @Valid UserRegisterRequest request){
@@ -30,14 +32,11 @@ public class UserController {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<String> login(@RequestBody @Valid UserLoginRequest request, HttpServletRequest httpRequest){
-    String result;
-
+  public ResponseEntity<String> login(@RequestBody @Valid UserLoginRequest request){
     boolean passed = userService.login(request.getUserId(), request.getPassword());
     if (passed) {
-      HttpSession session = httpRequest.getSession(true);
-      session.setAttribute("USER_ID", request.getUserId());
-      return ResponseEntity.ok("로그인 완료");
+      String token = jwtTokenProvider.generateToken(request.getUserId());
+      return ResponseEntity.ok("로그인 성공. JWT: " + token);
     } else {
       return ResponseEntity.status(401).body("로그인 실패");
     }

--- a/src/main/java/com/divelink/server/domain/DiveLog.java
+++ b/src/main/java/com/divelink/server/domain/DiveLog.java
@@ -1,14 +1,12 @@
 package com.divelink.server.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
-import java.sql.Date;
-import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -17,7 +15,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.w3c.dom.Text;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
@@ -25,29 +24,40 @@ import org.w3c.dom.Text;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)  // Auditing 기능 활성화
 public class DiveLog {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Column(nullable = false)
   private String userId;
 
+  @Column(nullable = false)
   private Integer divingNo;
+
+  @Column(nullable = false)
   private LocalDate date;
+
+  @Column(nullable = false)
   private LocalTime time;
+
+  @Column(nullable = false)
   private String location;
+
   private String suit;
   private Float weight;
-
   private Float fim;
   private Float cwt;
   private Float dyn;
-
   private String longestDivingTime;
 
   @Lob
+  @Column(nullable = false)
   private String content;
 
+  @CreatedDate
+  @Column(nullable = false)
   private LocalDateTime createdAt;
 
   @Lob

--- a/src/main/java/com/divelink/server/domain/DiveLog.java
+++ b/src/main/java/com/divelink/server/domain/DiveLog.java
@@ -1,0 +1,64 @@
+package com.divelink.server.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import java.sql.Date;
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.w3c.dom.Text;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DiveLog {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long userId;
+
+  private Integer divingNo;
+  private LocalDate date;
+  private LocalTime time;
+
+  private String location;
+  private String suit;
+
+  private Float weight;
+  private Float fim;
+  private Float cwt;
+  private Float dyn;
+
+  private String longestDivingTime;
+
+  @Lob
+  private String content;
+
+  @Enumerated(EnumType.STRING)
+  private Visibility visibility;
+
+  private LocalDateTime createdAt;
+
+  @Lob
+  private String comment;
+
+  public enum Visibility {
+    PRIVATE, BUDDY_ONLY, PUBLIC
+  }
+
+}

--- a/src/main/java/com/divelink/server/domain/DiveLog.java
+++ b/src/main/java/com/divelink/server/domain/DiveLog.java
@@ -30,16 +30,15 @@ public class DiveLog {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private Long userId;
+  private String userId;
 
   private Integer divingNo;
   private LocalDate date;
   private LocalTime time;
-
   private String location;
   private String suit;
-
   private Float weight;
+
   private Float fim;
   private Float cwt;
   private Float dyn;
@@ -49,16 +48,9 @@ public class DiveLog {
   @Lob
   private String content;
 
-  @Enumerated(EnumType.STRING)
-  private Visibility visibility;
-
   private LocalDateTime createdAt;
 
   @Lob
   private String comment;
-
-  public enum Visibility {
-    PRIVATE, BUDDY_ONLY, PUBLIC
-  }
 
 }

--- a/src/main/java/com/divelink/server/domain/User.java
+++ b/src/main/java/com/divelink/server/domain/User.java
@@ -1,0 +1,40 @@
+package com.divelink.server.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String userId;
+  private String name;
+  private String birthday;
+  private String password;
+
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
+  private LocalDateTime createdAt;
+
+  public enum Role{
+    ADMIN, USER
+  }
+}

--- a/src/main/java/com/divelink/server/dto/DiveLogRequest.java
+++ b/src/main/java/com/divelink/server/dto/DiveLogRequest.java
@@ -1,0 +1,29 @@
+package com.divelink.server.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DiveLogRequest {
+  private String userId; // 사용자 ID
+
+  private Integer divingNo; // 다이빙 번호
+  private LocalDate date; // 다이빙 날짜
+  private LocalTime time; // 다이빙 시간
+  private String location; // 다이빙 위치
+  private String suit; // 착용한 수트
+  private Float weight; // 체중
+
+  private Float fim; // FIM
+  private Float cwt; // CWT
+  private Float dyn; // DYN
+
+  private String longestDivingTime; // 최장 다이빙 시간
+
+  private String content; // 다이빙 내용
+
+  private String comment; // 다이빙 코멘트
+}

--- a/src/main/java/com/divelink/server/dto/UserLoginRequest.java
+++ b/src/main/java/com/divelink/server/dto/UserLoginRequest.java
@@ -1,0 +1,16 @@
+package com.divelink.server.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserLoginRequest {
+
+  @NotBlank(message = "아이디를 입력하세요.")
+  private String userId;
+
+  @NotBlank(message = "비밀번호를 입력하세요.")
+  private String password;
+}

--- a/src/main/java/com/divelink/server/dto/UserRegisterRequest.java
+++ b/src/main/java/com/divelink/server/dto/UserRegisterRequest.java
@@ -1,0 +1,27 @@
+package com.divelink.server.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserRegisterRequest {
+  @NotBlank(message = "아이디는 필수입니다.")
+  private String userId;
+
+  @NotBlank(message = "이름은 필수입니다.")
+  private String name;
+
+  @NotBlank(message = "생년월일은 필수입니다.")
+  @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "생년월일 형식은 yyyy-mm-dd입니다.")
+  private String birthday;
+
+  @NotBlank(message = "비밀번호는 필수입니다.")
+  @Pattern(
+      regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[^a-zA-Z0-9]).{7,}$",
+      message = "비밀번호는 영문자, 숫자, 특수문자를 포함한 7자 이상이어야 합니다."
+  )
+  private String password;
+}

--- a/src/main/java/com/divelink/server/repository/DiveLogRepository.java
+++ b/src/main/java/com/divelink/server/repository/DiveLogRepository.java
@@ -1,0 +1,8 @@
+package com.divelink.server.repository;
+
+import com.divelink.server.domain.DiveLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiveLogRepository extends JpaRepository<DiveLog, Long> {
+
+}

--- a/src/main/java/com/divelink/server/repository/UserRepository.java
+++ b/src/main/java/com/divelink/server/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.divelink.server.repository;
+
+import com.divelink.server.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByUserId(String id);
+}

--- a/src/main/java/com/divelink/server/service/DiveLogService.java
+++ b/src/main/java/com/divelink/server/service/DiveLogService.java
@@ -1,0 +1,45 @@
+package com.divelink.server.service;
+
+import com.divelink.server.domain.DiveLog;
+import com.divelink.server.dto.DiveLogRequest;
+import com.divelink.server.repository.DiveLogRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiveLogService {
+
+  private final DiveLogRepository diveLogRepository;
+
+  public String saveLog(DiveLogRequest request) {
+
+
+    try{
+      DiveLog diveLog = DiveLog.builder()
+          .userId(request.getUserId())
+          .divingNo(request.getDivingNo())
+          .date(request.getDate())
+          .time(request.getTime())
+          .location(request.getLocation())
+          .suit(request.getSuit())
+          .weight(request.getWeight())
+          .fim(request.getFim())
+          .cwt(request.getCwt())
+          .dyn(request.getDyn())
+          .longestDivingTime(request.getLongestDivingTime())
+          .content(request.getContent())
+          .comment(request.getComment())
+          .createdAt(LocalDateTime.now())
+          .build();
+
+      diveLogRepository.save(diveLog);
+
+      return "s";
+    } catch(Exception e){
+      return e.getMessage();
+    }
+
+  }
+}

--- a/src/main/java/com/divelink/server/service/DiveLogService.java
+++ b/src/main/java/com/divelink/server/service/DiveLogService.java
@@ -3,7 +3,6 @@ package com.divelink.server.service;
 import com.divelink.server.domain.DiveLog;
 import com.divelink.server.dto.DiveLogRequest;
 import com.divelink.server.repository.DiveLogRepository;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,9 +12,7 @@ public class DiveLogService {
 
   private final DiveLogRepository diveLogRepository;
 
-  public String saveLog(DiveLogRequest request) {
-
-
+  public void saveLog(DiveLogRequest request) throws Exception{
     try{
       DiveLog diveLog = DiveLog.builder()
           .userId(request.getUserId())
@@ -31,15 +28,11 @@ public class DiveLogService {
           .longestDivingTime(request.getLongestDivingTime())
           .content(request.getContent())
           .comment(request.getComment())
-          .createdAt(LocalDateTime.now())
           .build();
 
       diveLogRepository.save(diveLog);
-
-      return "s";
     } catch(Exception e){
-      return e.getMessage();
+      throw new Exception("로그 저장 중 오류 발생: " + e.getMessage(), e);
     }
-
   }
 }

--- a/src/main/java/com/divelink/server/service/UserService.java
+++ b/src/main/java/com/divelink/server/service/UserService.java
@@ -1,0 +1,39 @@
+package com.divelink.server.service;
+
+import com.divelink.server.domain.User;
+import com.divelink.server.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  public User register(String userId, String name, String birthday, String pw){
+    String encodedPw = encodePw(pw);
+    User user = User.builder()
+        .userId(userId)
+        .name(name)
+        .birthday(birthday)
+        .password(encodedPw)
+        .role(User.Role.USER) // 일반적인 경로로 회원가입 할 경우, 모두 일반 유저. 관리자는 개발자가 임의로 role 데이터 변경)
+        .createdAt(LocalDateTime.now())
+        .build();
+    return userRepository.save(user);
+  }
+
+  private String encodePw(String pw) {
+    return new BCryptPasswordEncoder().encode(pw);
+  }
+
+  public boolean login(String id, String password) {
+    return userRepository.findByUserId(id)
+        .map(user -> new BCryptPasswordEncoder().matches(password, user.getPassword()))
+        .orElse(false);
+  }
+}

--- a/src/main/java/com/divelink/server/service/UserService.java
+++ b/src/main/java/com/divelink/server/service/UserService.java
@@ -3,7 +3,6 @@ package com.divelink.server.service;
 import com.divelink.server.domain.User;
 import com.divelink.server.repository.UserRepository;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=DiveLink

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  datasource:
+    url: jdbc:mariadb://localhost:3306/divelink
+    username: root
+    password: ${DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update  # 개발 중에는 update, 배포 전에는 validate
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  security:
+    user:
+      enabled: false  # 기본 사용자 인증 비활성화
+
+#  jwt:
+#    expiration_time: 86400000 #1일
+#    secret:
+
+server:
+  port: 8080


### PR DESCRIPTION
### 변경사항
**AS-IS**
회원가입, 로그인, 로그아웃, 세션 확인 기능이 구현되지 않았음.
인증 및 세션 관리 기능이 구현되지 않음.
다이빙 로그 작성 기능이 구현되지 않았음

**TO-BE**

**회원가입 API (/users/register): 회원 정보를 받아서 새로운 유저를 등록하는 기능 추가.**
 -> 유저 ID, 이름, 생년월일, 비밀번호를 받아 유저를 등록하고 비밀번호는 BCryptPasswordEncoder로 암호화 후 저장.
 
**로그인 API (/users/login): 사용자가 제공한 ID와 비밀번호로 인증 후 JWT 토큰을 발급하고 USER_ID 세션 생성하는 기능 추가.**
 -> 로그인 성공 시 JWT 토큰을 Body에 반환하며, 이를 통해 다이빙 로그 작성 등의 보호된 리소스 접근 가능.
 
**로그아웃 API (/users/logout): 세션 삭제 및 로그아웃 처리.**
 -> 세션 기반 인증을 사용하며, 로그아웃 후 세션을 삭제하여 인증 상태를 종료.
 
**세션 확인 API (/users/session): 로그인 상태 확인을 위한 세션 확인 기능.**
 -> USER_ID 가 가진 값을 불러와서 세션 상태 확인 가능

**다이빙 로그 작성 API (/logs/write):** 
-> JWT 토큰을 이용해 다이빙 로그를 작성하는 기능 추가.
-> 헤더에 JWT 토큰을 포함시켜 인증을 받은 후 다이빙 로그 작성이 가능하도록 구현

### 테스트
- API 테스트 
Postman을 사용하여 api가 정상적으로 동작하는 테스트함