### PR TITLE
다이빙 로그 관련 기능 추가

### DIFF
--- a/src/main/java/com/divelink/server/config/JwtTokenProvider.java
+++ b/src/main/java/com/divelink/server/config/JwtTokenProvider.java
@@ -12,9 +12,10 @@ public class JwtTokenProvider {
   private final String SECRET_KEY = "mySuperSecretKeyThatIsAtLeast512BitsLongAndMoreSecureThanBeforemySuperSecretKeyThatIsAtLeast512BitsLongAndMoreSecureThanBefore";
 
   // JWT 토큰 생성
-  public String generateToken(String userId) {
+  public String generateToken(String userId, String userRole) {
     return Jwts.builder()
         .setSubject(userId) // 사용자 정보
+        .claim("role", userRole) //userRole도 추가
         .setIssuedAt(new Date()) // 토큰 발급 시간
         .setExpiration(new Date(System.currentTimeMillis() + 86400000)) // 만료 시간 1일
         .signWith(SignatureAlgorithm.HS512, SECRET_KEY) // 서명
@@ -38,5 +39,13 @@ public class JwtTokenProvider {
         .parseClaimsJws(token)
         .getBody()
         .getSubject();
+  }
+
+  public String getUserRoleFromToken(String token) {
+    return Jwts.parser()
+        .setSigningKey(SECRET_KEY)
+        .parseClaimsJws(token)
+        .getBody()
+        .get("role", String.class);
   }
 }

--- a/src/main/java/com/divelink/server/constant/SessionConst.java
+++ b/src/main/java/com/divelink/server/constant/SessionConst.java
@@ -1,0 +1,6 @@
+package com.divelink.server.constant;
+
+public class SessionConst {
+  public static final String USER_ID = "USER_ID";
+  public static final String USER_ROLE = "USER_ROLE";
+}

--- a/src/main/java/com/divelink/server/context/UserContext.java
+++ b/src/main/java/com/divelink/server/context/UserContext.java
@@ -1,0 +1,27 @@
+package com.divelink.server.context;
+
+public class UserContext {
+  private static final ThreadLocal<String> userIdHolder = new ThreadLocal<>();
+  private static final ThreadLocal<String> roleHolder = new ThreadLocal<>();
+
+  public static void setUserId(String userId) {
+    userIdHolder.set(userId);
+  }
+
+  public static String getUserId() {
+    return userIdHolder.get();
+  }
+
+  public static void setUserRole(String role) {
+    roleHolder.set(role);
+  }
+
+  public static String getUserRole() {
+    return roleHolder.get();
+  }
+
+  public static void clear() {
+    userIdHolder.remove();
+    roleHolder.remove();
+  }
+}

--- a/src/main/java/com/divelink/server/controller/DiveLogController.java
+++ b/src/main/java/com/divelink/server/controller/DiveLogController.java
@@ -1,13 +1,23 @@
 package com.divelink.server.controller;
 
+import com.divelink.server.domain.DiveLog;
+import com.divelink.server.dto.DiveLogCommentRequest;
 import com.divelink.server.dto.DiveLogRequest;
 import com.divelink.server.service.DiveLogService;
+import jakarta.servlet.http.HttpSession;
+import java.util.List;
+import javax.swing.Spring;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties.Http;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,12 +28,127 @@ public class DiveLogController {
   private final DiveLogService diveLogService;
 
   @PostMapping("write")
-  public ResponseEntity<String> writeLog(@RequestBody DiveLogRequest request){
+  public ResponseEntity<String> writeLog(@RequestBody DiveLogRequest request, HttpSession session){
     try{
-      diveLogService.saveLog(request);
+      if(session.getAttribute("USER_ID") == null || !session.getAttribute("USER_ID").equals(request.getUserId())){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+      String userId = (String) session.getAttribute("USER_ID");
+      diveLogService.saveLog(request, userId);
       return ResponseEntity.status(HttpStatus.CREATED).body("저장 성공");
     }catch(Exception e){
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("저장 실패" + e.getMessage());
+    }
+  }
+
+  @GetMapping("read-list")
+  public ResponseEntity<List<DiveLog>> diveLogList(HttpSession session){
+
+    try{
+      String userId = (String)session.getAttribute("USER_ID");
+      List<DiveLog> diveLogList = diveLogService.getDiveLogList(userId);
+      return ResponseEntity.ok(diveLogList);
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @GetMapping("user-read-detail")
+  public ResponseEntity<DiveLog> userDiveLog(@RequestParam Long id, HttpSession session){
+
+    try {
+      String userId = (String) session.getAttribute("USER_ID");
+      if (userId == null) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+      DiveLog diveLog = diveLogService.getDiveLog(userId, id);
+      return ResponseEntity.ok(diveLog);
+    }catch (IllegalArgumentException e){
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @PostMapping("modify-log")
+  public ResponseEntity<String> modifyLog (@RequestBody DiveLogRequest request, @RequestParam Long id, HttpSession session){
+    try{
+      if(session.getAttribute("USER_ID") == null){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+      String userId = (String) session.getAttribute("USER_ID");
+      diveLogService.modifyDiveLog(request, id, userId);
+      return ResponseEntity.ok("수정 성공");
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  //관리자가 특정 사용자의 다이빙 로그를 조회하는 API (comment 포함)
+  @GetMapping("admin-read-list")
+  public ResponseEntity<List<DiveLog>> diveLogList(@RequestParam String userId, HttpSession session){
+    try{
+      if(session.getAttribute("USER_ID") == null || !session.getAttribute("USER_ROLE").equals("ADMIN")){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+      return ResponseEntity.ok(diveLogService.getDiveLogList(userId));
+
+    }catch (Exception e){
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+  //관리자가 특정 id의 다이빙 로그를 조회하는 API (comment 포함)
+  @GetMapping("admin-read-log")
+  public ResponseEntity<DiveLog> adminDiveLog(@RequestParam Long id, HttpSession session){
+    try {
+      if (session.getAttribute("USER_ID") == null || !session.getAttribute("USER_ROLE").equals("ADMIN")) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+      DiveLog diveLog = diveLogService.getDiveLogByAdmin(id);
+      return ResponseEntity.ok(diveLog);
+    }catch (IllegalArgumentException e){
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @PostMapping("write-comment")
+  public ResponseEntity<String> writeComment(@RequestParam Long id, @RequestBody DiveLogCommentRequest comment, HttpSession session){
+    try{
+      if(session.getAttribute("USER_ID") == null || !session.getAttribute("USER_ROLE").equals("ADMIN")){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("권한 문제");
+      }
+      diveLogService.saveComment(id, comment.getComment());
+      return ResponseEntity.ok("comment 저장 완료");
+    }catch (Exception e){
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @PostMapping("modify-comment")
+  public ResponseEntity<String> modifyComment(@RequestParam Long id, @RequestBody DiveLogCommentRequest comment, HttpSession session){
+    try{
+      if(session.getAttribute("USER_ID") == null || !session.getAttribute("USER_ROLE").equals("ADMIN")){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("권한 문제");
+      }
+      diveLogService.saveComment(id, comment.getComment());
+      return ResponseEntity.ok("comment 업데이트 완료");
+    }catch (Exception e){
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @DeleteMapping("delete-comment")
+  public ResponseEntity<String> deleteComment(@RequestParam Long id, HttpSession session){
+    try{
+      if(session.getAttribute("USER_ID") == null || !"ADMIN".equals(session.getAttribute("USER_ROLE"))){
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("권한 문제");
+      }
+      diveLogService.deleteComment(id);
+      return ResponseEntity.ok("comment 삭제 완료");
+    }catch (Exception e){
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
 }

--- a/src/main/java/com/divelink/server/controller/UserController.java
+++ b/src/main/java/com/divelink/server/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.divelink.server.controller;
 
+import static com.divelink.server.constant.SessionConst.*;
 import com.divelink.server.config.JwtTokenProvider;
 import com.divelink.server.dto.UserLoginRequest;
 import com.divelink.server.dto.UserRegisterRequest;
@@ -43,9 +44,9 @@ public class UserController {
       boolean loginSuccess = userService.login(request.getUserId(), request.getPassword());
 
       if(loginSuccess){
-        String token = jwtTokenProvider.generateToken(request.getUserId());
-        session.setAttribute("USER_ID", request.getUserId());
-        session.setAttribute("USER_ROLE", userService.getUserRole(request.getUserId()));
+        String token = jwtTokenProvider.generateToken(request.getUserId(), userService.getUserRole(request.getUserId()));
+        session.setAttribute(USER_ID, request.getUserId());
+        session.setAttribute(USER_ROLE, userService.getUserRole(request.getUserId()));
         return ResponseEntity.ok("로그인 성공. JWT: " + token);
       }else{
         //아이디/비번 불일치 등
@@ -64,8 +65,8 @@ public class UserController {
 
   @GetMapping("/session")
   private ResponseEntity<String> checkSession(HttpSession session){
-    String userId = (String) session.getAttribute("USER_ID");
-    String role = (String) session.getAttribute("USER_ROLE");
+    String userId = (String) session.getAttribute(USER_ID);
+    String role = (String) session.getAttribute(USER_ROLE);
     if(userId != null){
       return ResponseEntity.ok("세션 있음 userId: " + userId + " user_role: " + role);
     }else{

--- a/src/main/java/com/divelink/server/controller/UserController.java
+++ b/src/main/java/com/divelink/server/controller/UserController.java
@@ -45,6 +45,7 @@ public class UserController {
       if(loginSuccess){
         String token = jwtTokenProvider.generateToken(request.getUserId());
         session.setAttribute("USER_ID", request.getUserId());
+        session.setAttribute("USER_ROLE", userService.getUserRole(request.getUserId()));
         return ResponseEntity.ok("로그인 성공. JWT: " + token);
       }else{
         //아이디/비번 불일치 등
@@ -64,8 +65,9 @@ public class UserController {
   @GetMapping("/session")
   private ResponseEntity<String> checkSession(HttpSession session){
     String userId = (String) session.getAttribute("USER_ID");
+    String role = (String) session.getAttribute("USER_ROLE");
     if(userId != null){
-      return ResponseEntity.ok("세션 있음 userId: " + userId);
+      return ResponseEntity.ok("세션 있음 userId: " + userId + " user_role: " + role);
     }else{
       return ResponseEntity.ok("세션 없음");
     }

--- a/src/main/java/com/divelink/server/dto/DiveLogCommentRequest.java
+++ b/src/main/java/com/divelink/server/dto/DiveLogCommentRequest.java
@@ -1,0 +1,10 @@
+package com.divelink.server.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DiveLogCommentRequest {
+  private String comment;
+}

--- a/src/main/java/com/divelink/server/dto/DiveLogRequest.java
+++ b/src/main/java/com/divelink/server/dto/DiveLogRequest.java
@@ -25,5 +25,5 @@ public class DiveLogRequest {
 
   private String content; // 다이빙 내용
 
-  private String comment; // 다이빙 코멘트
+//  private String comment; // 다이빙 코멘트
 }

--- a/src/main/java/com/divelink/server/repository/DiveLogRepository.java
+++ b/src/main/java/com/divelink/server/repository/DiveLogRepository.java
@@ -1,8 +1,17 @@
 package com.divelink.server.repository;
 
 import com.divelink.server.domain.DiveLog;
+import com.divelink.server.dto.DiveLogCommentRequest;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DiveLogRepository extends JpaRepository<DiveLog, Long> {
 
+  List<DiveLog> findAllByUserId(String userId);
+
+  @Modifying
+  @Query("UPDATE DiveLog SET comment = :comment WHERE id = :id")
+  void updateCommentById(Long id, String comment);
 }

--- a/src/main/java/com/divelink/server/repository/DiveLogRepository.java
+++ b/src/main/java/com/divelink/server/repository/DiveLogRepository.java
@@ -1,15 +1,15 @@
 package com.divelink.server.repository;
 
 import com.divelink.server.domain.DiveLog;
-import com.divelink.server.dto.DiveLogCommentRequest;
-import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface DiveLogRepository extends JpaRepository<DiveLog, Long> {
 
-  List<DiveLog> findAllByUserId(String userId);
+  Page<DiveLog> findAllByUserId(String userId, Pageable pageable);
 
   @Modifying
   @Query("UPDATE DiveLog SET comment = :comment WHERE id = :id")

--- a/src/main/java/com/divelink/server/repository/UserRepository.java
+++ b/src/main/java/com/divelink/server/repository/UserRepository.java
@@ -8,7 +8,4 @@ import org.springframework.data.jpa.repository.Query;
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByUserId(String id);
-
-  @Query("SELECT role FROM User WHERE userId = :userId")
-  String findRoleByUserId(String userId);
 }

--- a/src/main/java/com/divelink/server/repository/UserRepository.java
+++ b/src/main/java/com/divelink/server/repository/UserRepository.java
@@ -3,8 +3,12 @@ package com.divelink.server.repository;
 import com.divelink.server.domain.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByUserId(String id);
+
+  @Query("SELECT role FROM User WHERE userId = :userId")
+  String findRoleByUserId(String userId);
 }

--- a/src/main/java/com/divelink/server/service/DiveLogService.java
+++ b/src/main/java/com/divelink/server/service/DiveLogService.java
@@ -1,10 +1,14 @@
 package com.divelink.server.service;
 
 import com.divelink.server.domain.DiveLog;
+import com.divelink.server.dto.DiveLogCommentRequest;
 import com.divelink.server.dto.DiveLogRequest;
 import com.divelink.server.repository.DiveLogRepository;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,7 +16,7 @@ public class DiveLogService {
 
   private final DiveLogRepository diveLogRepository;
 
-  public void saveLog(DiveLogRequest request) throws Exception{
+  public void saveLog(DiveLogRequest request, String userId) throws Exception{
     try{
       DiveLog diveLog = DiveLog.builder()
           .userId(request.getUserId())
@@ -27,12 +31,57 @@ public class DiveLogService {
           .dyn(request.getDyn())
           .longestDivingTime(request.getLongestDivingTime())
           .content(request.getContent())
-          .comment(request.getComment())
           .build();
 
       diveLogRepository.save(diveLog);
     } catch(Exception e){
       throw new Exception("로그 저장 중 오류 발생: " + e.getMessage(), e);
     }
+  }
+
+  public List<DiveLog> getDiveLogList(String userId) {
+    return diveLogRepository.findAllByUserId(userId);
+  }
+
+  public DiveLog getDiveLog(String userId, Long id) {
+    return diveLogRepository.findById(id)
+        .filter(log -> log.getUserId().equals(userId))
+        .orElseThrow(() -> new IllegalArgumentException("권한이 없거나 존재하지 않는 로그입니다."));
+  }
+
+  public void modifyDiveLog(DiveLogRequest request, Long id, String userId) throws Exception{
+    DiveLog existing = diveLogRepository.findById(id)
+        .filter(diveLog -> diveLog.getUserId().equals(userId))
+        .orElseThrow(() -> new IllegalArgumentException("권한이 없거나 존재하지 않는 로그입니다."));
+    try{
+      existing.setDate(request.getDate());
+      existing.setTime(request.getTime());
+      existing.setLocation(request.getLocation());
+      existing.setSuit(request.getSuit());
+      existing.setWeight(request.getWeight());
+      existing.setFim(request.getFim());
+      existing.setCwt(request.getCwt());
+      existing.setDyn(request.getDyn());
+      existing.setLongestDivingTime(request.getLongestDivingTime());
+      existing.setContent(request.getContent());
+      diveLogRepository.save(existing);
+    }catch(Exception e){
+      throw new Exception("로그 수정 중 오류 발생: " + e.getMessage(), e);
+    }
+  }
+
+  public DiveLog getDiveLogByAdmin(Long id) {
+    return diveLogRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 id의 로그가 존재하지 않습니다."));
+  }
+
+  @Transactional
+  public void saveComment(Long id, String comment) {
+    diveLogRepository.updateCommentById(id, comment);
+  }
+
+  @Transactional
+  public void deleteComment(Long id) {
+    diveLogRepository.updateCommentById(id, null);
   }
 }

--- a/src/main/java/com/divelink/server/service/DiveLogService.java
+++ b/src/main/java/com/divelink/server/service/DiveLogService.java
@@ -1,11 +1,10 @@
 package com.divelink.server.service;
 
 import com.divelink.server.domain.DiveLog;
-import com.divelink.server.dto.DiveLogCommentRequest;
 import com.divelink.server.dto.DiveLogRequest;
 import com.divelink.server.repository.DiveLogRepository;
-import java.util.List;
-import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,8 +38,8 @@ public class DiveLogService {
     }
   }
 
-  public List<DiveLog> getDiveLogList(String userId) {
-    return diveLogRepository.findAllByUserId(userId);
+  public Page<DiveLog> getDiveLogList(String userId, Pageable pageable) {
+    return diveLogRepository.findAllByUserId(userId, pageable);
   }
 
   public DiveLog getDiveLog(String userId, Long id) {

--- a/src/main/java/com/divelink/server/service/UserService.java
+++ b/src/main/java/com/divelink/server/service/UserService.java
@@ -2,6 +2,7 @@ package com.divelink.server.service;
 
 import com.divelink.server.domain.User;
 import com.divelink.server.repository.UserRepository;
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -41,5 +42,9 @@ public class UserService {
     return userRepository.findByUserId(id)
         .map(user -> passwordEncoder.matches(password, user.getPassword()))
         .orElse(false);
+  }
+
+  public String getUserRole(String userId) {
+    return userRepository.findRoleByUserId(userId);
   }
 }

--- a/src/main/java/com/divelink/server/service/UserService.java
+++ b/src/main/java/com/divelink/server/service/UserService.java
@@ -45,6 +45,8 @@ public class UserService {
   }
 
   public String getUserRole(String userId) {
-    return userRepository.findRoleByUserId(userId);
+    return userRepository.findByUserId(userId)
+        .map(user -> user.getRole().name())
+        .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 유저"));
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->

**AS-IS**
- 다이빙 로그 관련 CRUD 기능이 존재하지 않았음
- 관리자의 댓글 기능 및 로그 열람 기능이 존재하지 않았음

**TO-BE**
- 사용자가 자신의 다이빙 로그를 작성, 조회, 수정할 수 있는 API 추가
  - `POST   /logs/write` : 다이빙 로그 작성
  - `GET    /logs/read-list` : 본인 로그 목록 조회
  - `GET    /logs/user-read-detail` : 본인 로그 상세 조회
  - `POST   /logs/modify-log` : 본인 로그 수정

- 관리자가 사용자의 다이빙 로그를 조회 및 댓글 관리할 수 있는 API 추가
  - `GET    /logs/admin-read-list` : 특정 사용자 로그 목록 조회
  - `GET    /logs/admin-read-log` : 특정 로그 상세 조회 (comment 포함)
  - `POST   /logs/write-comment` : 관리자 댓글 작성
  - `POST   /logs/modify-comment` : 관리자 댓글 수정
  - `DELETE /logs/delete-comment` : 관리자 댓글 삭제

- `DiveLogService`, `DiveLogController`, `DiveLogRepository` 구성 및 연결
- `updateCommentById()`를 통해 `comment` 필드를 업데이트하는 JPQL 쿼리 추가 (`@Modifying`, `@Transactional` 적용)


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] API 테스트 (Postman을 통해 사용자/관리자 권한 기반 기능 정상 작동 확인)