### PR TITLE
관리자 장비 등록 및 조회 기능

### DIFF
--- a/src/main/java/com/divelink/server/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/divelink/server/config/JwtAuthenticationFilter.java
@@ -11,6 +11,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -24,7 +26,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
-
     String token = getJwtFromRequest(request);
 
     if (token != null) {
@@ -32,12 +33,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     try{
-
-
       if (token != null && jwtTokenProvider.validateToken(token)) {
         String userId = jwtTokenProvider.getUserIdFromToken(token);
         String userRole = jwtTokenProvider.getUserRoleFromToken(token);
-        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, null);
+
+        List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(userRole));
+        log.info("Authorities: {}", authorities);
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         //UserContext 설정

--- a/src/main/java/com/divelink/server/config/JwtTokenProvider.java
+++ b/src/main/java/com/divelink/server/config/JwtTokenProvider.java
@@ -15,7 +15,7 @@ public class JwtTokenProvider {
   public String generateToken(String userId, String userRole) {
     return Jwts.builder()
         .setSubject(userId) // 사용자 정보
-        .claim("role", userRole) //userRole도 추가
+        .claim("role", "ROLE_" + userRole) //userRole도 추가
         .setIssuedAt(new Date()) // 토큰 발급 시간
         .setExpiration(new Date(System.currentTimeMillis() + 86400000)) // 만료 시간 1일
         .signWith(SignatureAlgorithm.HS512, SECRET_KEY) // 서명

--- a/src/main/java/com/divelink/server/config/SecurityConfig.java
+++ b/src/main/java/com/divelink/server/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.divelink.server.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -13,6 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity //@PreAuthorize 작동
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/divelink/server/controller/DiveLogController.java
+++ b/src/main/java/com/divelink/server/controller/DiveLogController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,133 +31,78 @@ public class DiveLogController {
 
   private final DiveLogService diveLogService;
 
-  private boolean isAdmin() {
-    return "ADMIN".equals(UserContext.getUserRole());
-  }
-
   // 다이빙 로그 작성
   @PostMapping
   public ResponseEntity<String> writeLog(@RequestBody DiveLogRequest request){
-    try{
-      String userId = UserContext.getUserId();
-      if(!userId.equals(request.getUserId())){
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-      }
-      diveLogService.saveLog(request, userId);
-      return ResponseEntity.status(HttpStatus.CREATED).body("저장 성공");
-    }catch(Exception e){
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("저장 실패" + e.getMessage());
+    String userId = UserContext.getUserId();
+    if(!userId.equals(request.getUserId())){
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
+    diveLogService.saveLog(request, userId);
+    return ResponseEntity.status(HttpStatus.CREATED).body("저장 성공");
   }
 
   // 사용자 본인 로그 목록 조회
   @GetMapping
   public ResponseEntity<Page<DiveLog>> diveLogList(@PageableDefault(size = 10, sort = "createdAt", direction = DESC) Pageable pageable){
-    try{
-      String userId = UserContext.getUserId();
-      Page<DiveLog> diveLogs = diveLogService.getDiveLogList(userId, pageable);
-      return ResponseEntity.ok(diveLogs);
-    } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
+    String userId = UserContext.getUserId();
+    Page<DiveLog> diveLogs = diveLogService.getDiveLogList(userId, pageable);
+    return ResponseEntity.ok(diveLogs);
   }
 
   //사용자 본인 특정 로그 조회
   @GetMapping("/{id}")
   public ResponseEntity<DiveLog> userDiveLog(@PathVariable Long id){
-
-    try {
-      String userId = UserContext.getUserId();
-      DiveLog diveLog = diveLogService.getDiveLog(userId, id);
-      return ResponseEntity.ok(diveLog);
-    }catch (IllegalArgumentException e){
-      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-    } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
+    String userId = UserContext.getUserId();
+    DiveLog diveLog = diveLogService.getDiveLog(userId, id);
+    return ResponseEntity.ok(diveLog);
   }
 
   //사용자 본인 로그 수정
   @PutMapping("/{id}")
   public ResponseEntity<String> modifyLog (@RequestBody DiveLogRequest request, @PathVariable Long id){
-    try{
-      String userId = UserContext.getUserId();
-      diveLogService.modifyDiveLog(request, id, userId);
-      return ResponseEntity.ok("수정 성공");
-    } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
+    String userId = UserContext.getUserId();
+    diveLogService.modifyDiveLog(request, id, userId);
+    return ResponseEntity.ok("수정 성공");
+
   }
 
   //관리자가 특정 사용자의 다이빙 로그를 조회하는 API (comment 포함)
+  @PreAuthorize("hasRole('ADMIN')")
   @GetMapping("/admin")
-  public ResponseEntity<Page<DiveLog>> adminDiveLogList(@RequestParam String userId,
-      @PageableDefault(size = 10, sort = "createdAt", direction = DESC) Pageable pageable){
-    try{
-      if(!isAdmin()){
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-      }
-      return ResponseEntity.ok(diveLogService.getDiveLogList(userId, pageable));
-
-    }catch (Exception e){
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
+  public ResponseEntity<Page<DiveLog>> adminDiveLogList(@RequestParam String userId, @PageableDefault(size = 10, sort = "createdAt", direction = DESC) Pageable pageable){
+    return ResponseEntity.ok(diveLogService.getDiveLogList(userId, pageable));
   }
+
   //관리자가 특정 id의 다이빙 로그를 조회하는 API (comment 포함)
+  @PreAuthorize("hasRole('ADMIN')")
   @GetMapping("/admin/{id}")
   public ResponseEntity<DiveLog> adminDiveLog(@PathVariable Long id){
-    try {
-      if(!isAdmin()){
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-      }
-      DiveLog diveLog = diveLogService.getDiveLogByAdmin(id);
-      return ResponseEntity.ok(diveLog);
-    }catch (IllegalArgumentException e){
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-    } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
+    DiveLog diveLog = diveLogService.getDiveLogByAdmin(id);
+    return ResponseEntity.ok(diveLog);
   }
 
   //관리자 코멘트 작성
+  @PreAuthorize("hasRole('ADMIN')")
   @PostMapping("/{id}/comments")
   public ResponseEntity<String> writeComment(@PathVariable Long id, @RequestBody DiveLogCommentRequest comment){
-    try{
-      if(!isAdmin()){
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("권한 문제");
-      }
-      diveLogService.saveComment(id, comment.getComment());
-      return ResponseEntity.ok("comment 저장 완료");
-    }catch (Exception e){
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
+    diveLogService.saveComment(id, comment.getComment());
+    return ResponseEntity.ok("comment 저장 완료");
   }
 
   //관리자 코멘트 수정
+  @PreAuthorize("hasRole('ADMIN')")
   @PutMapping("/comments/{id}")
   public ResponseEntity<String> modifyComment(@PathVariable Long id, @RequestBody DiveLogCommentRequest comment){
-    try{
-      if(!isAdmin()){
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("권한 문제");
-      }
-      diveLogService.saveComment(id, comment.getComment());
-      return ResponseEntity.ok("comment 업데이트 완료");
-    }catch (Exception e){
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
+    diveLogService.saveComment(id, comment.getComment());
+    return ResponseEntity.ok("comment 업데이트 완료");
   }
 
   //관리자 코멘트 삭제
+  @PreAuthorize("hasRole('ADMIN')")
   @DeleteMapping("/comments/{id}")
   public ResponseEntity<String> deleteComment(@PathVariable Long id){
-    try{
-      if(!isAdmin()){
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("권한 문제");
-      }
-      diveLogService.deleteComment(id);
-      return ResponseEntity.ok("comment 삭제 완료");
-    }catch (Exception e){
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-    }
+    diveLogService.deleteComment(id);
+    return ResponseEntity.ok("comment 삭제 완료");
   }
 }

--- a/src/main/java/com/divelink/server/controller/GearController.java
+++ b/src/main/java/com/divelink/server/controller/GearController.java
@@ -1,0 +1,50 @@
+package com.divelink.server.controller;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.divelink.server.context.UserContext;
+import com.divelink.server.dto.GearListRequest;
+import com.divelink.server.dto.GearRequest;
+import com.divelink.server.dto.GearSetWithGearListResponse;
+import com.divelink.server.service.GearService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/gear")
+@RequiredArgsConstructor
+public class GearController {
+
+  private final GearService gearService;
+
+  private boolean isAdmin() {
+    return "ADMIN".equals(UserContext.getUserRole());
+  }
+
+  //새로운 set 장비 등록
+  @PostMapping
+  public ResponseEntity<String> registerGear(@RequestBody GearListRequest request) {
+      if (!isAdmin()) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+      gearService.register(request.getGearList(), UserContext.getUserId());
+      return ResponseEntity.ok("등록 성공");
+  }
+
+  //장비 리스트 조회
+  @GetMapping
+  public ResponseEntity<List<GearSetWithGearListResponse>> getGear(@PageableDefault(size = 5, sort = "createdAt", direction = DESC) Pageable pageable){
+    String userId = UserContext.getUserId();
+    List<GearSetWithGearListResponse> list = gearService.getGearList(userId, pageable);
+    return ResponseEntity.ok(list);
+  }
+}

--- a/src/main/java/com/divelink/server/controller/GearController.java
+++ b/src/main/java/com/divelink/server/controller/GearController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,21 +32,17 @@ public class GearController {
   }
 
   //새로운 set 장비 등록
+  @PreAuthorize("hasRole('ADMIN')")
   @PostMapping
   public ResponseEntity<String> registerGear(@RequestBody GearListRequest request) {
-      if (!isAdmin()) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-      }
-      gearService.register(request.getGearList(), UserContext.getUserId());
-      return ResponseEntity.ok("등록 성공");
+    gearService.register(request.getGearList(), UserContext.getUserId());
+    return ResponseEntity.ok("등록 성공");
   }
 
   //장비 리스트 조회
+  @PreAuthorize("hasRole('ADMIN')")
   @GetMapping
-  public ResponseEntity<List<GearSetWithGearListResponse>> getGear(@PageableDefault(size = 5, sort = "createdAt", direction = DESC) Pageable pageable){
-    if (!isAdmin()) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-    }
+  public ResponseEntity<List<GearSetWithGearListResponse>> getGear(@PageableDefault(size = 2, sort = "createdAt", direction = DESC) Pageable pageable){
     String userId = UserContext.getUserId();
     List<GearSetWithGearListResponse> list = gearService.getGearList(userId, pageable);
     return ResponseEntity.ok(list);

--- a/src/main/java/com/divelink/server/controller/GearController.java
+++ b/src/main/java/com/divelink/server/controller/GearController.java
@@ -43,6 +43,9 @@ public class GearController {
   //장비 리스트 조회
   @GetMapping
   public ResponseEntity<List<GearSetWithGearListResponse>> getGear(@PageableDefault(size = 5, sort = "createdAt", direction = DESC) Pageable pageable){
+    if (!isAdmin()) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
     String userId = UserContext.getUserId();
     List<GearSetWithGearListResponse> list = gearService.getGearList(userId, pageable);
     return ResponseEntity.ok(list);

--- a/src/main/java/com/divelink/server/controller/UserController.java
+++ b/src/main/java/com/divelink/server/controller/UserController.java
@@ -26,34 +26,25 @@ public class UserController {
 
   @PostMapping("/register")
   public ResponseEntity<String> register(@RequestBody @Valid UserRegisterRequest request){
-    try{
-      boolean successRegister = userService.register(request.getUserId(), request.getName(), request.getBirthday(), request.getPassword());
-      if(successRegister){
-        return ResponseEntity.ok("회원가입 완료");
-      }else{
-        return ResponseEntity.status(HttpStatus.CONFLICT).body("등록 실패(이미 존재하는 아이디)");
-      }
-    } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("회원 등록 중 예외 발생: " + e.getMessage());
+    boolean successRegister = userService.register(request.getUserId(), request.getName(), request.getBirthday(), request.getPassword());
+    if(successRegister){
+      return ResponseEntity.ok("회원가입 완료");
+    }else{
+      return ResponseEntity.status(HttpStatus.CONFLICT).body("등록 실패(이미 존재하는 아이디)");
     }
   }
 
   @PostMapping("/login")
   public ResponseEntity<String> login(@RequestBody @Valid UserLoginRequest request, HttpSession session){
-    try{
-      boolean loginSuccess = userService.login(request.getUserId(), request.getPassword());
-
-      if(loginSuccess){
-        String token = jwtTokenProvider.generateToken(request.getUserId(), userService.getUserRole(request.getUserId()));
-        session.setAttribute(USER_ID, request.getUserId());
-        session.setAttribute(USER_ROLE, userService.getUserRole(request.getUserId()));
-        return ResponseEntity.ok("로그인 성공. JWT: " + token);
-      }else{
-        //아이디/비번 불일치 등
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 실패: 잘못된 데이터");
-      }
-    } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그인 처리 중 오류 발생: " + e.getMessage());
+    boolean loginSuccess = userService.login(request.getUserId(), request.getPassword());
+    if(loginSuccess){
+      String token = jwtTokenProvider.generateToken(request.getUserId(), userService.getUserRole(request.getUserId()));
+      session.setAttribute(USER_ID, request.getUserId());
+      session.setAttribute(USER_ROLE, userService.getUserRole(request.getUserId()));
+      return ResponseEntity.ok("로그인 성공. JWT: " + token);
+    }else{
+      //아이디/비번 불일치 등
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 실패: 잘못된 데이터");
     }
   }
 

--- a/src/main/java/com/divelink/server/domain/Gear.java
+++ b/src/main/java/com/divelink/server/domain/Gear.java
@@ -1,0 +1,41 @@
+package com.divelink.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Gear {
+@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private Integer price;
+
+  @Column(nullable = false)
+  private Integer quantity;
+
+  @CreatedDate
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(nullable = false)
+  private String createdBy;
+}

--- a/src/main/java/com/divelink/server/domain/GearSet.java
+++ b/src/main/java/com/divelink/server/domain/GearSet.java
@@ -1,0 +1,35 @@
+package com.divelink.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GearSet {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+//  @Column(nullable = false)
+//  private String name;
+
+  @CreatedDate
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(nullable = false)
+  private String createdBy;
+}

--- a/src/main/java/com/divelink/server/domain/GearSet.java
+++ b/src/main/java/com/divelink/server/domain/GearSet.java
@@ -1,11 +1,15 @@
 package com.divelink.server.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,4 +36,7 @@ public class GearSet {
 
   @Column(nullable = false)
   private String createdBy;
+
+  @OneToMany(mappedBy = "gearSet", cascade = CascadeType.ALL)
+  private List<GearSetMapping> mappings = new ArrayList<>();
 }

--- a/src/main/java/com/divelink/server/domain/GearSetMapping.java
+++ b/src/main/java/com/divelink/server/domain/GearSetMapping.java
@@ -2,9 +2,12 @@ package com.divelink.server.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,10 +24,12 @@ public class GearSetMapping {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
-  private Long gearSetId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "gear_set_id", nullable = false)
+  private GearSet gearSet;
 
-  @Column(nullable = false)
-  private Long gearId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "gear_id", nullable = false)
+  private Gear gear;
 
 }

--- a/src/main/java/com/divelink/server/domain/GearSetMapping.java
+++ b/src/main/java/com/divelink/server/domain/GearSetMapping.java
@@ -1,0 +1,30 @@
+package com.divelink.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GearSetMapping {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long gearSetId;
+
+  @Column(nullable = false)
+  private Long gearId;
+
+}

--- a/src/main/java/com/divelink/server/dto/GearListRequest.java
+++ b/src/main/java/com/divelink/server/dto/GearListRequest.java
@@ -1,0 +1,11 @@
+package com.divelink.server.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GearListRequest {
+  private List<GearRequest> gearList;
+}

--- a/src/main/java/com/divelink/server/dto/GearRequest.java
+++ b/src/main/java/com/divelink/server/dto/GearRequest.java
@@ -1,0 +1,16 @@
+package com.divelink.server.dto;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GearRequest {
+  private String name;
+  private Integer price;
+  private Integer quantity;
+  private String createdBy;
+}

--- a/src/main/java/com/divelink/server/dto/GearResponse.java
+++ b/src/main/java/com/divelink/server/dto/GearResponse.java
@@ -1,0 +1,19 @@
+package com.divelink.server.dto;
+
+import com.divelink.server.domain.Gear;
+import lombok.Getter;
+
+@Getter
+public class GearResponse {
+  private Long id;
+  private String name;
+  private Integer price;
+  private Integer quantity;
+
+  public GearResponse(Gear gear) {
+    this.id = gear.getId();
+    this.name = gear.getName();
+    this.price = gear.getPrice();
+    this.quantity = gear.getQuantity();
+  }
+}

--- a/src/main/java/com/divelink/server/dto/GearSetWithGearListResponse.java
+++ b/src/main/java/com/divelink/server/dto/GearSetWithGearListResponse.java
@@ -1,0 +1,15 @@
+package com.divelink.server.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class GearSetWithGearListResponse {
+  private Long setId;
+  private List<GearResponse> gears;
+
+  public GearSetWithGearListResponse(Long setId, List<GearResponse> gears) {
+    this.setId = setId;
+    this.gears = gears;
+  }
+}

--- a/src/main/java/com/divelink/server/dto/GearSetWithGearListResponse.java
+++ b/src/main/java/com/divelink/server/dto/GearSetWithGearListResponse.java
@@ -1,15 +1,12 @@
 package com.divelink.server.dto;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class GearSetWithGearListResponse {
   private Long setId;
   private List<GearResponse> gears;
-
-  public GearSetWithGearListResponse(Long setId, List<GearResponse> gears) {
-    this.setId = setId;
-    this.gears = gears;
-  }
 }

--- a/src/main/java/com/divelink/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/divelink/server/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.divelink.server.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<String> handleBadRequest(IllegalArgumentException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("잘못된 요청: " + e.getMessage());
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<String> handleValidation(MethodArgumentNotValidException e) {
+    String message = e.getBindingResult().getFieldError().getDefaultMessage();
+    return ResponseEntity.badRequest().body("유효성 검사 실패: " + message);
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<String> handleDBError(DataIntegrityViolationException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("DB 제약 조건 위반: " + e.getMessage());
+  }
+
+  @ExceptionHandler(EntityNotFoundException.class)
+  public ResponseEntity<String> handleNotFound(EntityNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body("엔티티 없음: " + e.getMessage());
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<String> handleJsonParse(HttpMessageNotReadableException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("요청 본문(JSON) 파싱 실패: " + e.getMessage());
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<String> handleServerError(Exception e) {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 내부 오류: " + e.getMessage());
+  }
+}

--- a/src/main/java/com/divelink/server/repository/GearRepository.java
+++ b/src/main/java/com/divelink/server/repository/GearRepository.java
@@ -1,0 +1,8 @@
+package com.divelink.server.repository;
+
+import com.divelink.server.domain.Gear;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GearRepository  extends JpaRepository<Gear, Long> {
+
+}

--- a/src/main/java/com/divelink/server/repository/GearSetMappingRepository.java
+++ b/src/main/java/com/divelink/server/repository/GearSetMappingRepository.java
@@ -1,0 +1,12 @@
+package com.divelink.server.repository;
+
+import com.divelink.server.domain.GearSetMapping;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GearSetMappingRepository extends JpaRepository<GearSetMapping, Long> {
+
+  List<GearSetMapping> findAllByGearSetId(Long setId);
+
+  List<GearSetMapping> findAllByGearSetIdIn(List<Long> setIds);
+}

--- a/src/main/java/com/divelink/server/repository/GearSetRepository.java
+++ b/src/main/java/com/divelink/server/repository/GearSetRepository.java
@@ -1,0 +1,11 @@
+package com.divelink.server.repository;
+
+import com.divelink.server.domain.GearSet;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GearSetRepository extends JpaRepository<GearSet, Long> {
+
+  List<GearSet> findAllByCreatedByOrderByCreatedAtDesc(String createdBy, Pageable pageable);
+}

--- a/src/main/java/com/divelink/server/repository/GearSetRepository.java
+++ b/src/main/java/com/divelink/server/repository/GearSetRepository.java
@@ -4,8 +4,13 @@ import com.divelink.server.domain.GearSet;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GearSetRepository extends JpaRepository<GearSet, Long> {
-
-  List<GearSet> findAllByCreatedByOrderByCreatedAtDesc(String createdBy, Pageable pageable);
+  @Query("SELECT gs FROM GearSet gs " +
+      "JOIN FETCH gs.mappings gsm " +
+      "JOIN FETCH gsm.gear g " +
+      "WHERE gs.createdBy = :createdBy " +
+      "ORDER BY gs.createdAt DESC")
+  List<GearSet> findWithMappingsAndGearsByCreatedBy(String createdBy, Pageable pageable);
 }

--- a/src/main/java/com/divelink/server/service/DiveLogService.java
+++ b/src/main/java/com/divelink/server/service/DiveLogService.java
@@ -15,27 +15,23 @@ public class DiveLogService {
 
   private final DiveLogRepository diveLogRepository;
 
-  public void saveLog(DiveLogRequest request, String userId) throws Exception{
-    try{
-      DiveLog diveLog = DiveLog.builder()
-          .userId(request.getUserId())
-          .divingNo(request.getDivingNo())
-          .date(request.getDate())
-          .time(request.getTime())
-          .location(request.getLocation())
-          .suit(request.getSuit())
-          .weight(request.getWeight())
-          .fim(request.getFim())
-          .cwt(request.getCwt())
-          .dyn(request.getDyn())
-          .longestDivingTime(request.getLongestDivingTime())
-          .content(request.getContent())
-          .build();
+  public void saveLog(DiveLogRequest request, String userId) {
+    DiveLog diveLog = DiveLog.builder()
+        .userId(request.getUserId())
+        .divingNo(request.getDivingNo())
+        .date(request.getDate())
+        .time(request.getTime())
+        .location(request.getLocation())
+        .suit(request.getSuit())
+        .weight(request.getWeight())
+        .fim(request.getFim())
+        .cwt(request.getCwt())
+        .dyn(request.getDyn())
+        .longestDivingTime(request.getLongestDivingTime())
+        .content(request.getContent())
+        .build();
 
-      diveLogRepository.save(diveLog);
-    } catch(Exception e){
-      throw new Exception("로그 저장 중 오류 발생: " + e.getMessage(), e);
-    }
+    diveLogRepository.save(diveLog);
   }
 
   public Page<DiveLog> getDiveLogList(String userId, Pageable pageable) {
@@ -48,25 +44,21 @@ public class DiveLogService {
         .orElseThrow(() -> new IllegalArgumentException("권한이 없거나 존재하지 않는 로그입니다."));
   }
 
-  public void modifyDiveLog(DiveLogRequest request, Long id, String userId) throws Exception{
+  public void modifyDiveLog(DiveLogRequest request, Long id, String userId){
     DiveLog existing = diveLogRepository.findById(id)
         .filter(diveLog -> diveLog.getUserId().equals(userId))
         .orElseThrow(() -> new IllegalArgumentException("권한이 없거나 존재하지 않는 로그입니다."));
-    try{
-      existing.setDate(request.getDate());
-      existing.setTime(request.getTime());
-      existing.setLocation(request.getLocation());
-      existing.setSuit(request.getSuit());
-      existing.setWeight(request.getWeight());
-      existing.setFim(request.getFim());
-      existing.setCwt(request.getCwt());
-      existing.setDyn(request.getDyn());
-      existing.setLongestDivingTime(request.getLongestDivingTime());
-      existing.setContent(request.getContent());
-      diveLogRepository.save(existing);
-    }catch(Exception e){
-      throw new Exception("로그 수정 중 오류 발생: " + e.getMessage(), e);
-    }
+    existing.setDate(request.getDate());
+    existing.setTime(request.getTime());
+    existing.setLocation(request.getLocation());
+    existing.setSuit(request.getSuit());
+    existing.setWeight(request.getWeight());
+    existing.setFim(request.getFim());
+    existing.setCwt(request.getCwt());
+    existing.setDyn(request.getDyn());
+    existing.setLongestDivingTime(request.getLongestDivingTime());
+    existing.setContent(request.getContent());
+    diveLogRepository.save(existing);
   }
 
   public DiveLog getDiveLogByAdmin(Long id) {

--- a/src/main/java/com/divelink/server/service/GearService.java
+++ b/src/main/java/com/divelink/server/service/GearService.java
@@ -1,0 +1,97 @@
+package com.divelink.server.service;
+
+import com.divelink.server.domain.Gear;
+import com.divelink.server.domain.GearSet;
+import com.divelink.server.domain.GearSetMapping;
+import com.divelink.server.dto.GearListRequest;
+import com.divelink.server.dto.GearRequest;
+import com.divelink.server.dto.GearResponse;
+import com.divelink.server.dto.GearSetWithGearListResponse;
+import com.divelink.server.repository.GearRepository;
+import com.divelink.server.repository.GearSetMappingRepository;
+import com.divelink.server.repository.GearSetRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GearService {
+
+  private final GearRepository gearRepository;
+  private final GearSetRepository gearSetRepository;
+  private final GearSetMappingRepository gearSetMappingRepository;
+
+  @Transactional
+  public void register(List<GearRequest> requests, String userId){
+    //1. GearSet 저장
+    GearSet set = GearSet.builder()
+        .createdAt(LocalDateTime.now())
+        .createdBy(userId)
+        .build();
+    gearSetRepository.save(set);
+
+    //2. Gear 저장
+    for(GearRequest request : requests){
+      Gear gear = Gear.builder()
+          .name(request.getName())
+          .price(request.getPrice())
+          .quantity(request.getQuantity())
+          .createdAt(LocalDateTime.now())
+          .createdBy(userId)
+          .build();
+      gearRepository.save(gear);
+
+      //3. GearSetMapping 저장
+      GearSetMapping mapping = GearSetMapping.builder()
+          .gearSetId(set.getId())
+          .gearId(gear.getId())
+          .build();
+      gearSetMappingRepository.save(mapping);
+    }
+  }
+
+  public List<GearSetWithGearListResponse> getGearList(String userId, Pageable pageable) {
+    //GearSet 목록 조회
+    List<GearSet> setList = gearSetRepository.findAllByCreatedByOrderByCreatedAtDesc(userId, pageable);
+    //GearSet Id 목록 추출
+    List<Long> setIds = setList.stream()
+        .map(GearSet::getId)
+        .toList();
+    //매핑정보 가져오기
+    List<GearSetMapping> setMappingList = gearSetMappingRepository.findAllByGearSetIdIn(setIds);
+    //Gear Id 목록 추출
+    List<Long> gearIds = setMappingList.stream()
+        .map(GearSetMapping::getGearId)
+        .toList();
+    //Gear 한번에 조회
+    List<Gear> gears = gearRepository.findAllById(gearIds);
+    Map<Long, Gear> gearMap = gears.stream()
+        .collect(Collectors.toMap(Gear::getId, g->g));
+
+    //setId -> List<GearResponse> 매핑
+    Map<Long, List<GearResponse>> setToGears = new HashMap<>();
+    for(GearSetMapping mapping : setMappingList){
+      Long setId = mapping.getGearSetId();
+      Gear gear = gearMap.get(mapping.getGearId());
+      GearResponse gearResponse = new GearResponse(gear);
+      setToGears.computeIfAbsent(setId, k -> new ArrayList<>()).add(gearResponse);
+    }
+
+    // 6. 최종 결과 변환
+    List<GearSetWithGearListResponse> result = new ArrayList<>();
+    for (GearSet set : setList){
+      Long setId = set.getId();
+      List<GearResponse> gearResponses = setToGears.getOrDefault(setId, List.of());
+      result.add(new GearSetWithGearListResponse(setId, gearResponses));
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/divelink/server/service/GearService.java
+++ b/src/main/java/com/divelink/server/service/GearService.java
@@ -61,16 +61,20 @@ public class GearService {
   public List<GearSetWithGearListResponse> getGearList(String userId, Pageable pageable) {
     //GearSet 목록 조회
     List<GearSet> setList = gearSetRepository.findAllByCreatedByOrderByCreatedAtDesc(userId, pageable);
+
     //GearSet Id 목록 추출
     List<Long> setIds = setList.stream()
         .map(GearSet::getId)
         .toList();
+
     //매핑정보 가져오기
     List<GearSetMapping> setMappingList = gearSetMappingRepository.findAllByGearSetIdIn(setIds);
+
     //Gear Id 목록 추출
     List<Long> gearIds = setMappingList.stream()
         .map(GearSetMapping::getGearId)
         .toList();
+
     //Gear 한번에 조회
     List<Gear> gears = gearRepository.findAllById(gearIds);
     Map<Long, Gear> gearMap = gears.stream()
@@ -85,7 +89,7 @@ public class GearService {
       setToGears.computeIfAbsent(setId, k -> new ArrayList<>()).add(gearResponse);
     }
 
-    // 6. 최종 결과 변환
+    //최종 결과 변환
     List<GearSetWithGearListResponse> result = new ArrayList<>();
     for (GearSet set : setList){
       Long setId = set.getId();


### PR DESCRIPTION
### 변경사항  
**AS-IS**  
- Gear 관련 API가 존재하지 않았음  
- 장비 등록과 조회 기능이 미구현 상태였음  

**TO-BE**  
- `GearController` 구현 완료  
  - `POST /gear`: 새로운 장비 세트를 등록하는 API 추가  
    - 한 번에 여러 개의 장비를 등록하고, GearSet 및 GearSetMapping 테이블과 연동  
  - `GET /gear`: 로그인한 유저가 등록한 GearSet 목록과 각각의 장비 목록을 조회하는 API 추가  
    - 페이지네이션 적용 (`size = 5`, 최신순 정렬)
- 인증 정보는 `UserContext`를 통해 가져오며, 등록 및 조회 API는 ADMIN만 가능

---

### 테스트  
- [x] API 테스트 (Postman을 통해 등록 및 조회 확인)  