### PR TITLE
finished PracticeNotice and PracticeApplication features

### DIFF
--- a/src/main/java/com/divelink/server/controller/PracticeNoticeController.java
+++ b/src/main/java/com/divelink/server/controller/PracticeNoticeController.java
@@ -1,0 +1,135 @@
+package com.divelink.server.controller;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.divelink.server.context.UserContext;
+import com.divelink.server.domain.Gear;
+import com.divelink.server.domain.PracticeApplication;
+import com.divelink.server.domain.PracticeNotice;
+import com.divelink.server.domain.User;
+import com.divelink.server.dto.GearSetWithGearListResponse;
+import com.divelink.server.dto.PracticeApplicationRequest;
+import com.divelink.server.dto.PracticeApplicationResponse;
+import com.divelink.server.dto.PracticeNoticeRequest;
+import com.divelink.server.dto.PracticeNoticeResponse;
+import com.divelink.server.service.GearService;
+import com.divelink.server.service.PracticeNoticeService;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/practice")
+@RequiredArgsConstructor
+public class PracticeNoticeController {
+
+  private final PracticeNoticeService practiceNoticeService;
+  private final GearService gearService;
+
+  //관리자 연습글 작성
+  @PreAuthorize("hasRole('ADMIN')")
+  @PostMapping("/notice")
+  public ResponseEntity<String> writePracticeNotice(@RequestBody PracticeNoticeRequest request){
+    String userId = UserContext.getUserId();
+    practiceNoticeService.writePracticeNotice(request, userId);
+    return ResponseEntity.ok("연습 공지 업로드 완료");
+  }
+  //관리자 연습글 조회
+  @PreAuthorize("hasRole('ADMIN')")
+  @GetMapping("/notice/admin")
+  public ResponseEntity<Page<PracticeNoticeResponse>> adminPracticeNotices(@PageableDefault(size = 2, sort = "createdAt", direction = DESC) Pageable pageable){
+    String userId = UserContext.getUserId();
+    Page<PracticeNoticeResponse> practiceNotices = practiceNoticeService.getPracticeNoticeListById(userId, pageable);
+    return ResponseEntity.ok(practiceNotices);
+  }
+
+  //관리자 연습글 수정
+  @PreAuthorize("hasRole('ADMIN')")
+  @PutMapping("/notice/modify/{id}")
+  public ResponseEntity<String> modifyPracticeNotice(@PathVariable Long id, @RequestBody PracticeNoticeRequest request){
+    practiceNoticeService.modifyPracticeNotice(id, request);
+    return ResponseEntity.ok("수정 완료");
+  }
+
+  //관리자 연습글 삭제
+  @PreAuthorize("hasRole('ADMIN')")
+  @DeleteMapping("notice/delete/{id}")
+  public ResponseEntity<String> deletePracticeNotice(@PathVariable Long id){
+    practiceNoticeService.deletePracticeNotice(id);
+    return ResponseEntity.ok("삭제 완료");
+  }
+
+  //사용자 연습글 조회
+  @GetMapping("/notice/user")
+  public ResponseEntity<Page<PracticeNoticeResponse>> userPracticeNotices(@PageableDefault(size = 2, sort = "createdAt", direction = DESC) Pageable pageable){
+    Page<PracticeNoticeResponse> practiceNotices = practiceNoticeService.getPracticeNoticeList(pageable);
+    return ResponseEntity.ok(practiceNotices);
+  }
+
+  //사용자 장비 리스트 조회
+  @GetMapping("/notice/gears")
+  public ResponseEntity<GearSetWithGearListResponse> getGear(@RequestParam Long gearSetId) {
+    GearSetWithGearListResponse gears = gearService.getGears(gearSetId);
+    return ResponseEntity.ok(gears);
+  }
+
+  //사용자 연습 신청
+  @PostMapping("/application")
+  public ResponseEntity<String> applyPractice(@RequestBody PracticeApplicationRequest request){
+    practiceNoticeService.apply(request, UserContext.getUserId());
+    return ResponseEntity.ok("신청 완료");
+  }
+
+  //연습 신청 조회
+  @GetMapping("/application")
+  public ResponseEntity<PracticeApplicationResponse> getApplicationInfo(@RequestParam Long practiceNoticeId){
+    PracticeApplicationResponse result = practiceNoticeService.getApplicationInfo(practiceNoticeId, UserContext.getUserId());
+    return ResponseEntity.ok(result);
+  }
+
+  //연습 신청 취소
+  @DeleteMapping("/application")
+  public ResponseEntity<String> cancelApplication(@RequestParam Long practiceApplicationId){
+    practiceNoticeService.cancelApplication(practiceApplicationId, UserContext.getUserId());
+    return ResponseEntity.ok("신청 취소 완료");
+  }
+
+  //사용자 입금 상태 변경 (1, 2, 3)
+  @PutMapping("/application/status")
+  public ResponseEntity<String> userChangeStatus(@RequestParam Long applicationId, @RequestParam int status){
+    if(status == 4 || status == 6){
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    } else if (status == 5) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("/practice/application path api를 이용하세요.");
+    }
+    practiceNoticeService.changeStatus(applicationId, status);
+    return ResponseEntity.ok("상태 변경 완료");
+  }
+
+  //관리자 입금 상태 변경 (4, 6)
+  @PreAuthorize("hasRole('ADMIN')")
+  @PutMapping("/admin/application/status")
+  public ResponseEntity<String> adminChangeStatus(@RequestParam Long applicationId, @RequestParam int status){
+    if(status == 1 || status == 2 || status == 3 || status == 5){
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    practiceNoticeService.changeStatus(applicationId, status);
+    return ResponseEntity.ok("상태 변경 완료");
+  }
+}

--- a/src/main/java/com/divelink/server/converter/GearIdListConverter.java
+++ b/src/main/java/com/divelink/server/converter/GearIdListConverter.java
@@ -1,0 +1,32 @@
+package com.divelink.server.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.List;
+
+@Converter
+public class GearIdListConverter implements AttributeConverter<List<Long>, String> {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public String convertToDatabaseColumn(List<Long> attribute) {
+    try {
+      return objectMapper.writeValueAsString(attribute);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("gearIds 변환 실패", e);
+    }
+  }
+
+  @Override
+  public List<Long> convertToEntityAttribute(String dbData) {
+    try {
+      return objectMapper.readValue(dbData, new TypeReference<List<Long>>() {});
+    } catch (Exception e) {
+      throw new IllegalArgumentException("gearIds 읽기 실패", e);
+    }
+  }
+}

--- a/src/main/java/com/divelink/server/domain/GearSetMapping.java
+++ b/src/main/java/com/divelink/server/domain/GearSetMapping.java
@@ -1,5 +1,6 @@
 package com.divelink.server.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/divelink/server/domain/PracticeApplication.java
+++ b/src/main/java/com/divelink/server/domain/PracticeApplication.java
@@ -1,0 +1,66 @@
+package com.divelink.server.domain;
+
+import com.divelink.server.converter.GearIdListConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PracticeApplication {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String userId;
+
+  @ManyToOne
+  @JoinColumn(name = "practice_notice_id", nullable = false)
+  private PracticeNotice practiceNotice;
+
+  @Enumerated(EnumType.STRING)
+  private Status status;
+
+  private Integer totalFee;
+  private LocalDateTime appliedAt;
+
+  @Convert(converter = GearIdListConverter.class)
+  @Column(columnDefinition = "TEXT") // MySQL 기준으로 JSON 저장 용도
+  private List<Long> gearIds;
+
+  public enum Status{
+    APPLIED(1),
+    PAYMENT_PENDING(2),
+    CONFIRM_REQUESTED(3),
+    PAYMENT_CONFIRMED(4),
+    CANCELLED(5),
+    REJECTED(6);
+
+    private final int code;
+    Status(int code) { this.code = code; }
+    public int getCode() { return code; }
+
+    public static Status fromCode(int code) {
+      for (Status s : values()) if (s.code == code) return s;
+      throw new IllegalArgumentException("잘못된 상태 코드: " + code);
+    }
+  }
+}

--- a/src/main/java/com/divelink/server/domain/PracticeNotice.java
+++ b/src/main/java/com/divelink/server/domain/PracticeNotice.java
@@ -1,0 +1,70 @@
+package com.divelink.server.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PracticeNotice {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false)
+  private LocalDate date;
+
+  @Column(nullable = false)
+  private LocalTime time;
+
+  @Column(nullable = false)
+  private String location;
+
+  private Integer maxParticipants;
+
+  @ManyToOne
+  @JoinColumn(name = "gear_set_id", nullable = false)
+  private GearSet gearSet;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private PaymentType paymentType;
+
+  @Column(nullable = false)
+  private String userId;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @OneToMany(mappedBy = "practiceNotice", cascade = CascadeType.ALL)
+  private List<PracticeApplication> applications = new ArrayList<>();
+
+  public enum PaymentType{
+    FREE, INDIVIDUAL, FLAT
+  }
+}

--- a/src/main/java/com/divelink/server/dto/GearResponse.java
+++ b/src/main/java/com/divelink/server/dto/GearResponse.java
@@ -1,9 +1,11 @@
 package com.divelink.server.dto;
 
 import com.divelink.server.domain.Gear;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class GearResponse {
   private Long id;
   private String name;

--- a/src/main/java/com/divelink/server/dto/PracticeApplicationRequest.java
+++ b/src/main/java/com/divelink/server/dto/PracticeApplicationRequest.java
@@ -1,0 +1,16 @@
+package com.divelink.server.dto;
+
+import com.divelink.server.domain.PracticeApplication.Status;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PracticeApplicationRequest {
+  private Long practiceNoticeId;       // 연습 공지 ID
+  private List<Long> gearIds;          // 신청한 장비 ID 목록
+  private Status status;               // 신청 상태 (선택적 - 기본값이라면 생략 가능)
+  private Integer totalFee;            // 총 대여 요금 (프론트에서 계산 or 서버 계산 여부에 따라 결정)
+}

--- a/src/main/java/com/divelink/server/dto/PracticeApplicationRequest.java
+++ b/src/main/java/com/divelink/server/dto/PracticeApplicationRequest.java
@@ -3,6 +3,7 @@ package com.divelink.server.dto;
 import com.divelink.server.domain.PracticeApplication.Status;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,7 +11,5 @@ import lombok.Setter;
 @Setter
 public class PracticeApplicationRequest {
   private Long practiceNoticeId;       // 연습 공지 ID
-  private List<Long> gearIds;          // 신청한 장비 ID 목록
-  private Status status;               // 신청 상태 (선택적 - 기본값이라면 생략 가능)
-  private Integer totalFee;            // 총 대여 요금 (프론트에서 계산 or 서버 계산 여부에 따라 결정)
+  private Set<Long> gearIds;          // 신청한 장비 ID 목록
 }

--- a/src/main/java/com/divelink/server/dto/PracticeApplicationResponse.java
+++ b/src/main/java/com/divelink/server/dto/PracticeApplicationResponse.java
@@ -1,0 +1,33 @@
+package com.divelink.server.dto;
+
+import com.divelink.server.domain.Gear;
+import com.divelink.server.domain.PracticeApplication;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PracticeApplicationResponse {
+  private Long id;
+  private String userId;
+  private PracticeNoticeSimpleResponse practiceNotice;
+  private PracticeApplication.Status status;
+  private Integer totalFee;
+  private LocalDateTime appliedAt;
+  private List<GearResponse> gears;
+
+  public static PracticeApplicationResponse from(PracticeApplication app, List<Gear> gearList) {
+    List<Gear> safeList = (gearList == null)? List.of() : gearList;
+    return new PracticeApplicationResponse(
+        app.getId(),
+        app.getUserId(),
+        PracticeNoticeSimpleResponse.from(app.getPracticeNotice()),
+        app.getStatus(),
+        app.getTotalFee(),
+        app.getAppliedAt(),
+        safeList.stream().map(GearResponse::new).toList()
+    );
+  }
+}

--- a/src/main/java/com/divelink/server/dto/PracticeNoticeRequest.java
+++ b/src/main/java/com/divelink/server/dto/PracticeNoticeRequest.java
@@ -1,0 +1,20 @@
+package com.divelink.server.dto;
+
+import com.divelink.server.domain.PracticeNotice.PaymentType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PracticeNoticeRequest {
+  private String title;
+  private LocalDate date;
+  private LocalTime time;
+  private String location;
+  private Integer maxParticipants;
+  private Long gearSetId;
+  private PaymentType paymentType;
+}

--- a/src/main/java/com/divelink/server/dto/PracticeNoticeResponse.java
+++ b/src/main/java/com/divelink/server/dto/PracticeNoticeResponse.java
@@ -1,0 +1,38 @@
+package com.divelink.server.dto;
+
+import com.divelink.server.domain.PracticeNotice;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+public class PracticeNoticeResponse {
+
+  private Long id;
+  private String title;
+  private LocalDate date;
+  private LocalTime time;
+  private String location;
+  private Integer maxParticipants;
+  private String paymentType;
+  private String gearSetCreatedBy; // 필요하다면 gearSet에서 가져올 필드
+  private String userId;
+
+  public static PracticeNoticeResponse from(PracticeNotice entity) {
+    return PracticeNoticeResponse.builder()
+        .id(entity.getId())
+        .title(entity.getTitle())
+        .date(entity.getDate())
+        .time(entity.getTime())
+        .location(entity.getLocation())
+        .maxParticipants(entity.getMaxParticipants())
+        .paymentType(entity.getPaymentType().name())
+        .gearSetCreatedBy(entity.getGearSet().getCreatedBy()) // 연관된 GearSet의 createdBy
+        .userId(entity.getUserId())
+        .build();
+  }
+}

--- a/src/main/java/com/divelink/server/dto/PracticeNoticeSimpleResponse.java
+++ b/src/main/java/com/divelink/server/dto/PracticeNoticeSimpleResponse.java
@@ -1,0 +1,21 @@
+package com.divelink.server.dto;
+
+import com.divelink.server.domain.PracticeNotice;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PracticeNoticeSimpleResponse {
+  private Long id;
+  private String title;
+  private String location;
+
+  public static PracticeNoticeSimpleResponse from(PracticeNotice notice) {
+    return new PracticeNoticeSimpleResponse(
+        notice.getId(),
+        notice.getTitle(),
+        notice.getLocation()
+    );
+  }
+}

--- a/src/main/java/com/divelink/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/divelink/server/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -40,5 +41,10 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(Exception.class)
   public ResponseEntity<String> handleServerError(Exception e) {
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 내부 오류: " + e.getMessage());
+  }
+
+  @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
+  public ResponseEntity<String> handleDenied(AccessDeniedException e) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body("권한 없음: " + e.getMessage());
   }
 }

--- a/src/main/java/com/divelink/server/repository/GearRepository.java
+++ b/src/main/java/com/divelink/server/repository/GearRepository.java
@@ -1,8 +1,36 @@
 package com.divelink.server.repository;
 
 import com.divelink.server.domain.Gear;
+import com.divelink.server.repository.projection.GearCapacityRow;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GearRepository  extends JpaRepository<Gear, Long> {
 
+  @Query(value = """
+SELECT 
+  g.id AS gearId,
+  g.quantity AS capacity,
+  g.price AS price,
+  COALESCE(SUM(
+    CASE 
+      WHEN pa.id IS NOT NULL 
+       AND FIND_IN_SET(
+                   CAST(g.id AS CHAR),
+                   REPLACE(REPLACE(REPLACE(pa.gear_ids, '[',''),']',''), '"','')
+                 ) > 0
+      THEN 1 ELSE 0 
+    END
+  ), 0) AS used
+FROM gear g
+LEFT JOIN practice_application pa
+  ON pa.practice_notice_id = :noticeId
+ AND pa.status IN ('PAYMENT_PENDING','CONFIRM_REQUESTED','PAYMENT_CONFIRMED')
+WHERE g.id IN (:gearIds)
+GROUP BY g.id, g.quantity, g.price
+""", nativeQuery = true)
+  List<GearCapacityRow> checkCapacityForNotice(@Param("noticeId") Long noticeId,
+      @Param("gearIds") List<Long> gearIds);
 }

--- a/src/main/java/com/divelink/server/repository/PracticeApplicationRepository.java
+++ b/src/main/java/com/divelink/server/repository/PracticeApplicationRepository.java
@@ -1,0 +1,13 @@
+package com.divelink.server.repository;
+
+import com.divelink.server.domain.PracticeApplication;
+import com.divelink.server.domain.PracticeNotice;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PracticeApplicationRepository extends JpaRepository<PracticeApplication, Long> {
+
+  Optional<PracticeApplication> findByUserIdAndPracticeNotice(String userId, PracticeNotice practiceNotice);
+
+  int deleteByIdAndUserId(Long practiceApplicationId, String userId);
+}

--- a/src/main/java/com/divelink/server/repository/PracticeApplicationRepository.java
+++ b/src/main/java/com/divelink/server/repository/PracticeApplicationRepository.java
@@ -4,10 +4,22 @@ import com.divelink.server.domain.PracticeApplication;
 import com.divelink.server.domain.PracticeNotice;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PracticeApplicationRepository extends JpaRepository<PracticeApplication, Long> {
 
   Optional<PracticeApplication> findByUserIdAndPracticeNotice(String userId, PracticeNotice practiceNotice);
 
   int deleteByIdAndUserId(Long practiceApplicationId, String userId);
+
+  Optional<PracticeApplication> findByIdAndUserId(Long id, String userId);
+
+  // 공지 ID만 빠르게 얻어서 락에 활용 (불필요한 연관 로딩 최소화)
+  @Query("select a.practiceNotice.id from PracticeApplication a where a.id = :appId")
+  Optional<Long> findNoticeIdByApplicationId(@Param("appId") Long applicationId);
+
+  // 필요시: 수정/취소 시 검증을 위해 함께 로딩
+  @Query("select a from PracticeApplication a join fetch a.practiceNotice where a.id = :id")
+  Optional<PracticeApplication> findWithNoticeById(@Param("id") Long id);
 }

--- a/src/main/java/com/divelink/server/repository/PracticeNoticeRepository.java
+++ b/src/main/java/com/divelink/server/repository/PracticeNoticeRepository.java
@@ -1,0 +1,20 @@
+package com.divelink.server.repository;
+
+import com.divelink.server.domain.PracticeNotice;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PracticeNoticeRepository extends JpaRepository<PracticeNotice, Long> {
+
+  Page<PracticeNotice> findAllByUserId(String userId, Pageable pageable);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select pn from PracticeNotice pn where pn.id = :id")
+  Optional<PracticeNotice> findByIdForUpdate(@Param("id") Long id);
+}

--- a/src/main/java/com/divelink/server/repository/projection/GearCapacityRow.java
+++ b/src/main/java/com/divelink/server/repository/projection/GearCapacityRow.java
@@ -1,0 +1,8 @@
+package com.divelink.server.repository.projection;
+
+public interface GearCapacityRow {
+  Long getGearId();
+  Integer getCapacity();
+  Integer getPrice();
+  Long getUsed(); // 집계 값은 Long이 더 안전 (COUNT/SUM 결과)
+}

--- a/src/main/java/com/divelink/server/service/GearService.java
+++ b/src/main/java/com/divelink/server/service/GearService.java
@@ -10,6 +10,7 @@ import com.divelink.server.dto.GearSetWithGearListResponse;
 import com.divelink.server.repository.GearRepository;
 import com.divelink.server.repository.GearSetMappingRepository;
 import com.divelink.server.repository.GearSetRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -71,4 +72,18 @@ public class GearService {
         })
         .toList();
   }
+
+  public GearSetWithGearListResponse getGears(Long gearSetId) {
+    List<GearResponse> gears = gearSetMappingRepository.findAllByGearSetId(gearSetId).stream()
+        .map(GearSetMapping::getGear)
+        .map(gear -> new GearResponse(gear.getId(), gear.getName(), gear.getPrice(), gear.getQuantity()))
+        .toList();
+
+    return new GearSetWithGearListResponse(gearSetId, gears);
+  }
+
+//  public Map<String, Integer> getRentalInfoByUserId(String userId, Long practiceNoticeId) {
+//
+//  }
+
 }

--- a/src/main/java/com/divelink/server/service/PracticeNoticeService.java
+++ b/src/main/java/com/divelink/server/service/PracticeNoticeService.java
@@ -1,0 +1,181 @@
+package com.divelink.server.service;
+
+import com.divelink.server.domain.Gear;
+import com.divelink.server.domain.GearSet;
+import com.divelink.server.domain.PracticeApplication;
+import com.divelink.server.domain.PracticeApplication.Status;
+import com.divelink.server.domain.PracticeNotice;
+import com.divelink.server.dto.PracticeApplicationRequest;
+import com.divelink.server.dto.PracticeApplicationResponse;
+import com.divelink.server.dto.PracticeNoticeRequest;
+import com.divelink.server.dto.PracticeNoticeResponse;
+import com.divelink.server.repository.GearRepository;
+import com.divelink.server.repository.GearSetRepository;
+import com.divelink.server.repository.PracticeApplicationRepository;
+import com.divelink.server.repository.PracticeNoticeRepository;
+import com.divelink.server.repository.projection.GearCapacityRow;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class PracticeNoticeService {
+
+  private final PracticeNoticeRepository practiceNoticeRepository;
+  private final PracticeApplicationRepository practiceApplicationRepository;
+  private final GearSetRepository gearSetRepository;
+  private final GearRepository gearRepository;
+
+  public void writePracticeNotice(PracticeNoticeRequest request, String userId) {
+    GearSet gearSet = gearSetRepository.findById(request.getGearSetId())
+        .orElseThrow(()->new IllegalArgumentException("GearSet not found"));
+
+    PracticeNotice notice = PracticeNotice.builder()
+        .title(request.getTitle())
+        .date(request.getDate())
+        .time(request.getTime())
+        .location(request.getLocation())
+        .maxParticipants(request.getMaxParticipants())
+        .gearSet(gearSet)
+        .paymentType(request.getPaymentType())
+        .userId(userId)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    practiceNoticeRepository.save(notice);
+  }
+
+  public Page<PracticeNoticeResponse> getPracticeNoticeListById(String userId, Pageable pageable) {
+    return practiceNoticeRepository.findAllByUserId(userId, pageable)
+        .map(PracticeNoticeResponse::from);
+  }
+
+  public Page<PracticeNoticeResponse> getPracticeNoticeList(Pageable pageable) {
+    return practiceNoticeRepository.findAll(pageable)
+        .map(PracticeNoticeResponse::from);
+  }
+
+  @Transactional
+  public void modifyPracticeNotice(Long id, PracticeNoticeRequest request) {
+    PracticeNotice notice = practiceNoticeRepository.findById(id)
+        .orElseThrow(()-> new EntityNotFoundException("존재하지 않는 연습공지 id"));
+
+    GearSet gearSet = gearSetRepository.findById(request.getGearSetId())
+        .orElseThrow(()-> new EntityNotFoundException("존재하지 않는 gearSet id"));
+
+    notice.setTitle(request.getTitle());
+    notice.setDate(request.getDate());
+    notice.setTime(request.getTime());
+    notice.setLocation(request.getLocation());
+    notice.setMaxParticipants(request.getMaxParticipants());
+    notice.setGearSet(gearSet);
+    notice.setPaymentType(request.getPaymentType());
+  }
+
+  public void deletePracticeNotice(Long id) {
+    practiceNoticeRepository.deleteById(id);
+  }
+  @Transactional
+  public void apply(PracticeApplicationRequest request, String userId) {
+    PracticeNotice practiceNotice = practiceNoticeRepository.findByIdForUpdate(request.getPracticeNoticeId())
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 공지글"));
+
+    List<Long> requestedGearIds = request.getGearIds();
+
+    //장비를 대여하지 않는 신청일 경우
+    if(requestedGearIds == null && requestedGearIds.isEmpty()){
+      PracticeApplication application = PracticeApplication.builder()
+          .userId(userId)
+          .practiceNotice(practiceNotice)
+          .status(Status.APPLIED)
+          .totalFee(0)
+          .appliedAt(LocalDateTime.now())
+          .gearIds(Collections.emptyList())
+          .build();
+      practiceApplicationRepository.save(application);
+      return;
+    }
+
+    Set<Long> unique = new LinkedHashSet<>(requestedGearIds);
+    if (unique.size() != requestedGearIds.size()) {
+      throw new IllegalArgumentException("장비 중복 선택 불가 (중복 gearId)");
+    }
+    List<Long> ids = new ArrayList<>(unique);
+
+    // 2) 집계 한 번으로 capacity/used/price 가져오기
+    List<GearCapacityRow> rows = gearRepository.checkCapacityForNotice(practiceNotice.getId(), ids);
+
+    if (rows.size() != ids.size()) {
+      throw new IllegalArgumentException("존재하지 않는 장비 ID 포함");
+    }
+
+    // 3) 재고 검증 + 총액 계산
+    int totalFee = 0;
+    for (GearCapacityRow r : rows) {
+      int remain = (int) (r.getCapacity() - r.getUsed());
+      if (remain <= 0) {
+        throw new IllegalArgumentException("장비 재고 부족: gearId=" + r.getGearId());
+      }
+      totalFee += r.getPrice(); // 각 장비 1개씩 가정
+    }
+
+    PracticeApplication application = PracticeApplication.builder()
+        .userId(userId)
+        .practiceNotice(practiceNotice)
+        .status(Status.PAYMENT_PENDING)
+        .totalFee(totalFee)
+        .appliedAt(LocalDateTime.now())
+        .gearIds(ids)
+        .build();
+    practiceApplicationRepository.save(application);
+  }
+
+  public PracticeApplicationResponse getApplicationInfo(Long practiceNoticeId, String userId) {
+    PracticeNotice practiceNotice = practiceNoticeRepository.findById(practiceNoticeId)
+        .orElseThrow(()-> new EntityNotFoundException("공지글 없음"));
+
+    PracticeApplication applicationInfo = practiceApplicationRepository.findByUserIdAndPracticeNotice(userId, practiceNotice)
+        .orElseThrow(()->new EntityNotFoundException("신청 내역을 찾을 수 없음"));
+
+    List<Long> gearIds = applicationInfo.getGearIds();
+    List<Gear> gears = (gearIds == null)? Collections.emptyList() : gearRepository.findAllById(gearIds);
+
+    return PracticeApplicationResponse.from(applicationInfo, gears);
+  }
+
+  @Transactional
+  public void cancelApplication(Long applicationId, String userId) {
+//    int affected = practiceApplicationRepository.deleteByIdAndUserId(practiceApplicationId, userId);
+//    if(affected == 0){
+//      throw new EntityNotFoundException("신청 내역이 없거나 이미 삭제됨");
+//    }//DELETE 로직
+
+    PracticeApplication app = practiceApplicationRepository.findById(applicationId)
+        .orElseThrow(() -> new EntityNotFoundException("신청 내역 없음"));
+    if (!userId.equals(app.getUserId())) {
+      throw new IllegalArgumentException("본인 신청만 취소할 수 있습니다.");
+    }
+    if(app.getStatus() == Status.PAYMENT_CONFIRMED) throw new RuntimeException("확정 이후 취소 불가");
+    app.setStatus(Status.CANCELLED);
+  }
+
+  @Transactional
+  public void changeStatus(Long applicationId, int statusCode) {
+    PracticeApplication application = practiceApplicationRepository.findById(applicationId)
+        .orElseThrow(()-> new EntityNotFoundException("유효하지 않는 신청"));
+    if(application.getStatus() == Status.PAYMENT_CONFIRMED){
+      throw new IllegalArgumentException("확정 후 변경 불가");
+    }
+    PracticeApplication.Status status = PracticeApplication.Status.fromCode(statusCode);
+    application.setStatus(status);
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->

**AS-IS**
- 연습 공지/신청 관련 API 부재
- 엔티티 직접 반환으로 순환 참조 및 과다 응답 발생 가능
- 장비 목록 조회 API 부재, 상태코드(Number) ↔ Enum 매핑/검증 로직 없음

**TO-BE**
- 연습 공지/신청 도메인 API 추가 및 정리 (`/practice/**`)
  - **관리자**
    - `POST   /practice/notice` : 연습 공지 등록
    - `GET    /practice/notice/admin` : 관리자 공지 목록 조회 (Paging)
    - `PUT    /practice/notice/modify/{id}` : 공지 수정
    - `DELETE /practice/notice/delete/{id}` : 공지 삭제
    - `PUT    /practice/admin/application/status` : 신청 상태 변경 (코드 4=PAYMENT_CONFIRMED, 6=REJECTED)
  - **사용자**
    - `GET    /practice/notice/user` : 사용자 공지 목록 조회 (Paging)
    - `GET    /practice/notice/gears?gearSetId=` : 공지의 GearSet 장비 목록 조회 → `GearSetWithGearListResponse(GearResponse[])`
    - `POST   /practice/application` : 연습 신청 (장비 선택 시 총 대여료 합산)
    - `GET    /practice/application?practiceNoticeId=` : 본인 신청 상세 조회 → `PracticeApplicationResponse`
    - `DELETE /practice/application?practiceApplicationId=` : 신청 취소
    - `PUT    /practice/application/status?applicationId=&status=` : 사용자 상태 변경 (코드 1~3만 허용)
- **DTO 도입**: `PracticeNoticeRequest/Response`, `PracticeApplicationRequest/Response`, `GearSetWithGearListResponse`, `GearResponse`  
  → 엔티티 직접 노출 제거, 순환 참조 방지, 응답 스펙 고정
- **상태코드 매핑**: `PracticeApplication.Status`에 `code`/`fromCode(int)` 추가로 숫자 코드(1~6) 기반 업데이트 지원
- **권한/검증 강화**
  - 사용자: 상태 1~3만 변경 가능, 취소는 전용 API 사용 유도
  - 관리자: 상태 4/6만 변경 가능
  - 확정 이후 변경 차단 (`PAYMENT_CONFIRMED` 변경 불가)
- **페이징 응답**: 공지 목록 `Page<PracticeNoticeResponse>`로 반환 (메타 포함)
- **트랜잭션/영속성**
  - 변경 메서드에 `@Transactional` 적용 (Dirty Checking으로 업데이트 반영)
  - 삭제 시 `deleteByIdAndUserId` 사용 및 영향 행 수 검증
  - 연습별 장비 사용량 집계/검증 및 동시성 제어
  - 동일 공지에 대한 동시 신청 직렬화를 위한 비관적 락 (`findByIdForUpdate`)
  - 네이티브 집계 쿼리로 사용량/수량/가격 일괄 조회 (MariaDB 호환 `FIND_IN_SET` 활용)

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] API 테스트 (Postman으로 테스트 완료)
